### PR TITLE
docs: fix Node.JS SDK example

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -67,7 +67,7 @@ Then, create a tunnel in your Node.js application:
 import { pinggy } from "@pinggy/pinggy";
 
 
-const tunnel = pinggy.createTunnel({ forwarding: "localhost:3000" });
+const tunnel = await pinggy.createTunnel({ forwarding: "localhost:3000" });
 await tunnel.start();
 console.log("Tunnel URLs:", await tunnel.urls()); // Get all public urls
 ```


### PR DESCRIPTION
`pinggy.createTunnel` returns a Promise which needs to be awaited. See e.g. the [SDK readme](https://github.com/Pinggy-io/sdk-nodejs?tab=readme-ov-file#quick-start)