### PR TITLE
Add YouTube video to Minecraft server blog post

### DIFF
--- a/content/blog/exposing_localhost_minecraft_server.md
+++ b/content/blog/exposing_localhost_minecraft_server.md
@@ -27,6 +27,8 @@ In this guide, we'll walk through the process of exposing your localhost Minecra
 
 {{% /tldr %}}
 
+{{< iframe src="https://www.youtube.com/embed/jwHRK6rYDIs" title="How to Host a Minecraft Server for Friends Online (No Port Forwarding)" >}}
+
 ## Installing Minecraft Launcher
 
 To embark on your Minecraft adventure, the first step is to install the Minecraft Launcher. Follow these detailed instructions to ensure a smooth installation process.


### PR DESCRIPTION
Added a YouTube video embed to the "Sharing a Minecraft Server running on Localhost with Your Friends Online" blog post. The video is placed immediately after the TLDR section for better visibility. The embed uses the project's standard `iframe` shortcode.

Fixes #661

---
*PR created automatically by Jules for task [16461913111189407394](https://jules.google.com/task/16461913111189407394) started by @ghoshbishakh*