### PR TITLE
Give the blog an editorial identity separate from the product site

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,8 +1,12 @@
 ---
-title: Blogs
+title: "Pinggy Blog - Tunnels, Networking, Self-Hosted LLMs & AI"
+description: "Hands-on guides and deep dives on localhost tunnels, SSH, reverse proxies, self-hosting, self-hosted LLMs, and AI news - written by the team building Pinggy."
+heading: "Tunnels, networking, self-hosted LLMs, and AI news"
 date: 2023-02-23
 publishdate: 2023-02-23
 aliases:
   - /blog/new/
   - /blog/new
 ---
+
+Hands-on guides, protocol deep dives, and field notes on tunnels, SSH, reverse proxies, self-hosting, self-hosted LLMs, and AI - from the people building <a href="/">Pinggy</a>.

--- a/content/blog/updated/_index.md
+++ b/content/blog/updated/_index.md
@@ -1,6 +1,9 @@
 ---
-title: "Recently Updated Blog Posts"
-description: "Pinggy blog posts sorted by their most recent update."
+title: "Recently Updated - Pinggy Blog"
+description: "Pinggy blog posts sorted by their most recent update - guides on tunnels, networking, self-hosting, self-hosted LLMs, and AI, kept current."
+heading: "Recently updated posts"
 sort: "updated"
 canonical: "https://pinggy.io/blog/"
 ---
+
+The latest revisions across our writing on tunnels, networking, self-hosting, self-hosted LLMs, and AI - freshest updates first.

--- a/content/blog/updated/_index.md
+++ b/content/blog/updated/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Recently Updated - Pinggy Blog"
-description: "Pinggy blog posts sorted by their most recent update - guides on tunnels, networking, self-hosting, self-hosted LLMs, and AI, kept current."
+description: "Pinggy blog recently updated posts - guides on tunnels, networking, self-hosting, self-hosted LLMs, and AI."
 heading: "Recently updated posts"
 sort: "updated"
 canonical: "https://pinggy.io/blog/"

--- a/layouts/blog/baseof.amp.html
+++ b/layouts/blog/baseof.amp.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <title>
-      {{ if .IsHome }}Pinggy - Simple Localhost Tunnels{{ else }}{{ if
-      .Page.Title }}{{ .Page.Title }} - {{.Site.Title}}{{ end }}{{ end }}
+      {{- if and (eq .Section "blog") (eq .Kind "page") }}{{ .Title }} | Pinggy Blog
+      {{- else if .Page.Title }}{{ .Page.Title }} - {{.Site.Title}}{{ end -}}
     </title>
 
     <!-- Favicon-->
@@ -79,10 +79,33 @@
       .navbar {
         display: flex;
         align-items: center;
+        justify-content: space-between;
         padding: 0 3rem;
       }
-      .navbar .logo img {
-        max-height: 60px;
+      .navbar .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
+        text-decoration: none;
+      }
+      .navbar .brand img {
+        max-height: 30px;
+      }
+      .navbar .brand-sep {
+        width: 1px;
+        height: 22px;
+        background: #d9dde4;
+      }
+      .navbar .brand-label {
+        font-weight: 300;
+        font-size: 16px;
+        color: #6b7686;
+      }
+      .navbar .nav-contact {
+        font-weight: 600;
+        font-size: 14.5px;
+        color: #344155;
+        text-decoration: none;
       }
       .container {
         max-width: 800px;
@@ -222,15 +245,16 @@
     </amp-analytics>
     <header>
       <nav class="navbar">
-        <div class="logo">
-          <a href="/">
-            <img
-              src="/assets/pinggy_logo.webp"
-              alt="Pinggy brand logo"
-              height="50"
-            />
-          </a>
-        </div>
+        <a class="brand" href="/">
+          <img
+            src="/assets/pinggy_logo.webp"
+            alt="Pinggy brand logo"
+            height="30"
+          />
+          <span class="brand-sep"></span>
+          <span class="brand-label">Technical Blog</span>
+        </a>
+        <a class="nav-contact" href="/contact_us/">Contact</a>
       </nav>
     </header>
     <main class="container">

--- a/layouts/blog/baseof.html
+++ b/layouts/blog/baseof.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Source+Sans+3:ital,wght@0,400;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;500;600;700;800&family=Source+Sans+3:ital,wght@0,400;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;600&display=swap"
       rel="stylesheet"
     />
     <link href="/css/blog.css?v=23" rel="stylesheet" />
@@ -17,7 +17,7 @@
 
   <body class="{{ if eq .Kind "page" }}blogpost{{ end }}">
     {{- partial "grid_canvas.html" . }}
-    {{- partial "navbar.html" .}}
+    {{- partial "blog-navbar.html" .}}
 
     <div class="container py-3 contentcontainer maincontent">
       <div class="row flex-nowrap row justify-content-evenly">

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -9,18 +9,17 @@
 {{ $isNew := not $isUpdated }}
 {{ $posts := $blog.RegularPages }}
 {{ $posts = cond $isUpdated ($posts.ByLastmod.Reverse) ($posts.ByDate.Reverse) }}
-<main>
-  <div
-    class="row justify-content-center"
-    style="max-width: 800px; margin: 0 auto"
-  >
+<div class="bp">
+<main class="bp-list">
+  <div class="row justify-content-center">
     <div class="col-12 col-md-12">
-      <header>
-        <h1 class="display-4">Blog</h1>
+      <header class="bp-list__masthead">
+        <span class="bp-list__eyebrow">Pinggy Blog</span>
+        <h1 class="bp-list__title">{{ .Params.heading | default "Tunnels, networking, self-hosted LLMs, and AI news" }}</h1>
+        <!-- Lede pulls from the markdown of the corresponding _index.md -->
+        <div class="bp-list__lede">{{ .Content }}</div>
       </header>
-      <hr />
-      <!-- "{{.Content}}" pulls from the markdown content of the corresponding _index.md -->
-      {{.Content}}
+      <hr class="bp-list__rule" />
 
       <!-- Sort toggle. Each option is a real URL: /blog/ (newest by publish
            date) and /blog/updated/ (recently updated by lastmod). -->
@@ -107,4 +106,5 @@
     </div>
   </div>
 </main>
+</div>
 {{ end }}

--- a/layouts/partials/blog-navbar.html
+++ b/layouts/partials/blog-navbar.html
@@ -1,0 +1,64 @@
+<!-- Minimal editorial navbar for the blog. Deliberately free of the product
+     nav's Compare / Download / Dashboard items so the blog reads as a
+     technical publication, not a marketing surface. Styles live under
+     `.bp-nav` in static/css/blog.css and load only on blog pages. -->
+<nav class="bp-nav" aria-label="Blog">
+  <div class="bp-nav__inner">
+    <a class="bp-nav__brand" href="/" aria-label="Pinggy home">
+      <img
+        class="bp-nav__logo"
+        src="/assets/pinggy_logo.webp"
+        alt="Pinggy"
+        width="76"
+        height="30"
+      />
+      <span class="bp-nav__sep" aria-hidden="true"></span>
+      <span class="bp-nav__label">Technical Blog</span>
+    </a>
+
+    <div class="bp-nav__links">
+      <a class="bp-nav__text" href="/contact_us/">Contact</a>
+
+      <a
+        class="bp-nav__icon"
+        href="https://github.com/pinggy-io"
+        title="Pinggy on GitHub"
+        aria-label="Pinggy on GitHub"
+        rel="noopener"
+        target="_blank"
+      >
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path
+            d="M12 1.5A10.5 10.5 0 001.5 12c0 4.64 3 8.57 7.18 9.96.53.1.72-.23.72-.5v-1.8c-2.92.63-3.54-1.25-3.54-1.25-.48-1.21-1.17-1.54-1.17-1.54-.95-.65.08-.64.08-.64 1.06.08 1.61 1.09 1.61 1.09.94 1.6 2.46 1.14 3.06.87.1-.68.37-1.14.66-1.4-2.33-.27-4.78-1.16-4.78-5.18 0-1.14.41-2.08 1.08-2.81-.11-.27-.47-1.34.1-2.8 0 0 .88-.28 2.88 1.07a10 10 0 015.24 0c2-1.35 2.88-1.07 2.88-1.07.57 1.46.21 2.53.1 2.8.67.73 1.08 1.67 1.08 2.81 0 4.03-2.46 4.9-4.8 5.16.38.33.71.97.71 1.96v2.9c0 .28.19.61.73.5A10.5 10.5 0 0022.5 12 10.5 10.5 0 0012 1.5z"
+          />
+        </svg>
+      </a>
+
+      <a
+        class="bp-nav__icon"
+        href="https://discord.com/invite/KX5DpTs3xx"
+        title="Pinggy on Discord"
+        aria-label="Pinggy on Discord"
+        rel="noopener"
+        target="_blank"
+      >
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path
+            d="M20.3 4.4A19.8 19.8 0 0015.4 3l-.3.5c1.7.4 2.5.9 3.4 1.6a13.3 13.3 0 00-10.9 0c.9-.7 1.9-1.3 3.4-1.6L10.6 3a19.8 19.8 0 00-4.9 1.4C2.5 9 1.6 13.6 2 18.1A19.9 19.9 0 008 21l.6-1c-1-.3-1.9-.7-2.7-1.3l.6-.4a14.2 14.2 0 0012.2 0l.6.4c-.8.6-1.7 1-2.7 1.3l.6 1a19.9 19.9 0 005.9-2.9c.5-5.2-.8-9.7-2.8-13.7zM9.3 15.4c-1 0-1.7-.9-1.7-1.9s.8-1.9 1.7-1.9 1.7.9 1.7 1.9-.7 1.9-1.7 1.9zm5.4 0c-1 0-1.7-.9-1.7-1.9s.8-1.9 1.7-1.9 1.7.9 1.7 1.9-.7 1.9-1.7 1.9z"
+          />
+        </svg>
+      </a>
+
+      <a
+        class="bp-nav__icon bp-nav__icon--img"
+        href="https://forum.pinggy.io/"
+        title="Pinggy Community Forum"
+        aria-label="Pinggy Community Forum"
+        rel="noopener"
+        target="_blank"
+      >
+        <img src="/assets/pinggy_forum_logo.png" alt="" width="20" height="20" />
+      </a>
+    </div>
+  </div>
+</nav>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,8 +2,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 <title>
-  {{ if .IsHome }}Pinggy - Simple Localhost Tunnels{{ else }}{{ if .Page.Title
-  }}{{ .Page.Title }}{{ end }}{{ end }}
+  {{- if .IsHome }}Pinggy - Simple Localhost Tunnels
+  {{- else if and (eq .Section "blog") (eq .Kind "page") }}{{ .Title }} | Pinggy Blog
+  {{- else if .Page.Title }}{{ .Page.Title }}{{ end -}}
 </title>
 
 <!-- Favicon-->

--- a/layouts/partials/seoblogs.html
+++ b/layouts/partials/seoblogs.html
@@ -3,7 +3,7 @@
 <meta property="og:type" content="article" />
 <meta
   property="og:title"
-  content="{{ if .IsHome }}Pinggy - Simple Localhost Tunnels{{ else }}{{ if .Page.Title }}{{ .Page.Title }} - {{.Site.Title}}{{ end }}{{ end }}"
+  content="{{ if and (eq .Section "blog") (eq .Kind "page") }}{{ .Title }} | Pinggy Blog{{ else if .Page.Title }}{{ .Page.Title }} - {{.Site.Title}}{{ end }}"
 />
 
 {{ $metaDescription := .Params.description }} {{ if not $metaDescription }} {{
@@ -18,11 +18,11 @@ $metaDescription = .Summary }} {{ end }}
 <meta property="og:site_name" content="{{ $siteName }}" />
 <meta
   property="article:published_time"
-  content='{{.Date.Format "2006-01-02"}}T14:07:59+00:00'
+  content='{{ .Date.Format "2006-01-02T15:04:05-07:00" }}'
 />
 <meta
   property="article:modified_time"
-  content='{{.Date.Format "2006-01-02"}}T14:07:59+00:00'
+  content='{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" }}'
 />
 {{ if .Params.og_image }}
 <meta property="og:image" content="{{ .Params.og_image | absURL }}" />
@@ -55,8 +55,8 @@ $metaDescription = .Summary }} {{ end }}
     "https://pinggy.io/assets/pinggy_logo.png"
     {{ end }}
      ],
-    "datePublished": "{{.Date.Format "2006-01-02"}}T14:07:59+00:00",
-    "dateModified": "{{.Date.Format "2006-01-02"}}T14:07:59+00:00",
+    "datePublished": "{{ .Date.Format "2006-01-02T15:04:05-07:00" }}",
+    "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05-07:00" }}",
     "author": [{
         "@type": "Organization",
         "name": "Pinggy",

--- a/static/css/blog.css
+++ b/static/css/blog.css
@@ -369,8 +369,157 @@ body::before {
 @media (max-width: 560px) { .bp-endcard { flex-wrap: wrap; } .bp-endcard__cta { margin-left: 0; width: 100%; text-align: center; } }
 
 /* ---------------------------------------------------------------------------
+   Blog navbar (editorial). Lives outside the `.bp` wrapper (it sits in
+   baseof above the article and the list), so it carries its own palette
+   values instead of the `.bp` custom properties. Kept intentionally sparse:
+   wordmark + "Technical Blog", a Contact link, and community icons. No
+   Compare / Download / Dashboard - those product signals are what make a
+   blog read as a marketing page. blog.css loads only on blog pages, so this
+   never touches the product site.
+   --------------------------------------------------------------------------- */
+/* The site-wide fixed navbar left a 4.8em top offset on .contentcontainer;
+   this editorial nav sits in normal flow (sticky), so reclaim that space. */
+.contentcontainer { margin-top: 0; }
+
+.bp-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(251, 250, 248, 0.85);
+  -webkit-backdrop-filter: saturate(180%) blur(10px);
+  backdrop-filter: saturate(180%) blur(10px);
+  border-bottom: 1px solid #e9ebf0;
+}
+.bp-nav__inner {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 12px clamp(20px, 5vw, 48px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+.bp-nav__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  text-decoration: none;
+}
+.bp-nav__logo { height: 30px; width: auto; display: block; }
+.bp-nav__sep { width: 1px; height: 22px; background: #d9dde4; }
+.bp-nav__label {
+  font-family: "Plus Jakarta Sans", system-ui, sans-serif;
+  font-weight: 300;
+  font-size: 16px;
+  letter-spacing: 0.02em;
+  color: #6b7686;
+  white-space: nowrap;
+}
+.bp-nav__links {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.bp-nav__text {
+  font-family: "Plus Jakarta Sans", system-ui, sans-serif;
+  font-weight: 600;
+  font-size: 14.5px;
+  color: #344155;
+  text-decoration: none;
+  padding: 6px 12px;
+  border-radius: 8px;
+  transition: color 0.15s, background 0.15s;
+}
+.bp-nav__text:hover { color: #1d4ed8; background: #eef2fe; }
+.bp-nav__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  color: #6b7686;
+  transition: color 0.15s, background 0.15s;
+}
+.bp-nav__icon:hover { color: #1f2a37; background: #eef2fe; }
+.bp-nav__icon svg { width: 20px; height: 20px; display: block; }
+.bp-nav__icon--img img { width: 20px; height: 20px; display: block; }
+.bp-nav a:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+  border-radius: 8px;
+}
+@media (max-width: 480px) {
+  .bp-nav__label { display: none; }
+  .bp-nav__sep { display: none; }
+}
+
+/* ---------------------------------------------------------------------------
+   Blog list (editorial). Wrapped in `.bp` in layouts/blog/list.html so it
+   inherits the reading typefaces and palette. These rules retune the
+   masthead and the shared `.blog-card` markup (styled for the product site
+   in customization.css) into the same editorial voice as the posts: mono
+   for meta, Plus Jakarta for headings, the blog blue for links. Scoped under
+   `.bp` so the product site's cards (e.g. tag term pages) are untouched.
+   --------------------------------------------------------------------------- */
+.bp-list { max-width: 820px; margin: 0 auto; padding: clamp(28px, 5vw, 52px) 0 24px; }
+.bp-list__masthead { margin-bottom: 8px; }
+.bp-list__eyebrow {
+  display: inline-flex; align-items: center; gap: 9px;
+  font-family: var(--ui); font-weight: 700; font-size: 13px;
+  letter-spacing: 0.14em; text-transform: uppercase; color: var(--accent-strong);
+}
+.bp-list__eyebrow::before { content: ""; width: 22px; height: 2px; border-radius: 2px; background: var(--accent); }
+.bp-list__title {
+  font-family: var(--ui); font-weight: 800; color: var(--ink);
+  font-size: clamp(30px, 4.4vw, 42px); line-height: 1.08; letter-spacing: -0.02em;
+  margin: 14px 0 10px;
+}
+.bp-list__lede {
+  font-family: var(--sans); color: var(--body);
+  font-size: 18px; line-height: 1.6; max-width: 62ch; margin: 0;
+}
+.bp-list__lede a { color: var(--accent-strong); text-decoration: none; border-bottom: 1px solid var(--accent-soft-border); }
+.bp-list__lede a:hover { border-bottom-color: var(--accent); }
+.bp-list__rule { border: none; border-top: 1px solid var(--rule); margin: 22px 0 4px; }
+
+/* Retune the shared card markup under `.bp`. */
+.bp .blog-card { border-bottom-color: var(--rule); }
+.bp .blog-card__media { border-color: var(--rule); border-radius: 12px; background: var(--bg-tint); }
+/* Re-assert cover sizing: `.bp img { height: auto }` ties `.blog-card__media
+   img` on specificity but loads later, which would otherwise leave the image
+   short of the 120px frame. This two-class selector wins cleanly. */
+.bp .blog-card__media img { width: 100%; height: 100%; object-fit: cover; }
+.bp .blog-card__placeholder { color: var(--faint); }
+.bp .blog-card__title {
+  font-family: var(--ui); font-weight: 700; color: var(--ink); letter-spacing: -0.01em;
+}
+.bp .blog-card__titlelink:hover .blog-card__title { color: var(--accent-strong); }
+.bp .blog-card__meta {
+  font-family: var(--mono); font-size: 12.5px; color: var(--muted); text-transform: none;
+}
+.bp .blog-card__meta time { color: var(--ink-2); }
+.bp .blog-card__tag {
+  font-family: var(--ui); font-weight: 600; font-size: 11.5px;
+  background: var(--accent-soft); color: var(--accent-strong); border-radius: 999px; padding: 2px 9px;
+}
+.bp .blog-card__excerpt { font-family: var(--sans); color: var(--muted); font-size: 15px; }
+
+/* Sort toggle: keep the segmented control, recolor to the blog palette. */
+.bp .blog-sort-label { font-family: var(--ui); color: var(--muted); }
+.bp .blog-sort { background: var(--bg-tint); border-color: var(--rule-strong); }
+.bp .blog-sort__btn { font-family: var(--ui); color: var(--muted); }
+.bp .blog-sort__btn.is-active { color: var(--ink); }
+.bp .blog-sort__btn:focus-visible { box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35); }
+
+/* Pagination under `.bp`. */
+.bp .pagination { font-family: var(--ui); }
+.bp .pagination .page-link { color: var(--accent-strong); border-color: var(--rule); }
+.bp .pagination .active .page-link { background: var(--accent); border-color: var(--accent); color: #fff; }
+
+/* ---------------------------------------------------------------------------
    Motion
    --------------------------------------------------------------------------- */
 @media (prefers-reduced-motion: reduce) {
-  .bp *, .bp-progress__fill { transition: none !important; }
+  .bp *, .bp-progress__fill, .bp-nav a { transition: none !important; }
 }


### PR DESCRIPTION
- Add a minimal blog navbar (logo + "Technical Blog", Contact link, GitHub/Discord/Forum icons); drop the product nav's Compare/Download/ Dashboard items so blog pages don't read as a marketing surface.
- Bring the list page into the .bp editorial type system with a proper masthead; retune the shared blog-card markup (mono meta, blog blue).
- Fix blog meta: consistent "Title | Pinggy Blog" titles, real title/description on the list + updated pages, and correct schema dates (dateModified/modified_time now use Lastmod, real timestamps instead of a hardcoded time). Title changes scoped to the blog section so tools/quickstart/know_your_port are untouched.
- Load Plus Jakarta Sans 300 so the nav label renders truly light.

## Checklist  
- [ ] OG image is added.  
- [ ] Headings are properly structured.  
- [ ] `{{< link href=... >}}` tag is used for links.  
- [ ] Article summary is included.  
- [ ] In the summary section, use `<a href="URL" target="_blank">` for external links.  
- [ ] Content is reviewed for grammar and clarity.  
- [ ] Code compiles and runs locally without errors.  